### PR TITLE
Add new-tab flashcards to the landing page; sync privacy claims

### DIFF
--- a/index.css
+++ b/index.css
@@ -1258,6 +1258,250 @@ section {
   color: #86efac;
 }
 
+/* ----- New tab flashcards ----- */
+
+.ntab-frame {
+  position: relative;
+  max-width: 900px;
+  margin: 56px auto 0;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #f6f6f4;
+  border: 1px solid var(--border);
+  box-shadow: 0 60px 120px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.ntab-chrome {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: #ededeb;
+  border-bottom: 1px solid var(--border);
+}
+.ntab-omni {
+  flex: 1;
+  max-width: 420px;
+  margin: 0 auto;
+  background: var(--white);
+  border: 1px solid var(--border);
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--ink-dim);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.ntab-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+}
+.ntab-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink-mid);
+}
+.ntab-brand img {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+}
+.ntab-iconbtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--ink-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ntab-clock {
+  text-align: center;
+  padding: 14px 0 30px;
+}
+.ntab-time-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 8px;
+}
+.ntab-time {
+  font-size: clamp(48px, 9vw, 68px);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--ink);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.ntab-ampm {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--ink-dim);
+}
+.ntab-sub {
+  color: var(--ink-mid);
+  font-size: 15px;
+  margin-top: 12px;
+}
+
+.ntab-cardwrap {
+  max-width: 460px;
+  margin: 0 auto;
+  padding: 0 20px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.ntab-card {
+  background: var(--white);
+  border: 1px solid rgba(29, 29, 31, 0.07);
+  border-radius: 18px;
+  padding: 28px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.06);
+}
+
+.ntab-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: rgba(29, 29, 31, 0.06);
+  border-radius: 999px;
+  padding: 5px 12px 5px 10px;
+  margin-bottom: 16px;
+  max-width: 100%;
+}
+.ntab-pill .dot {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+.ntab-pill .txt {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink-mid);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ntab-q {
+  color: var(--ink);
+  font-weight: 700;
+  font-size: 19px;
+  line-height: 1.45;
+  margin: 0 0 22px;
+}
+
+.ntab-opts {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.ntab-opt {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  background: #f2f2f0;
+  border: 1px solid rgba(29, 29, 31, 0.07);
+  border-radius: 11px;
+  padding: 14px 16px;
+  color: var(--ink);
+  font-size: 15px;
+}
+.ntab-opt .otext { flex: 1; }
+.ntab-opt svg { flex: none; }
+.ntab-opt--correct {
+  background: rgba(21, 128, 61, 0.1);
+  border-color: rgba(21, 128, 61, 0.4);
+  color: #166534;
+}
+.ntab-opt--correct .check { stroke: #15803d; }
+.ntab-opt--wrong {
+  background: rgba(196, 58, 58, 0.09);
+  border-color: rgba(196, 58, 58, 0.36);
+  color: #b3261e;
+}
+.ntab-opt--wrong .cross { stroke: #c43a3a; }
+.ntab-opt--dim { color: var(--ink-dim); }
+
+.ntab-note {
+  margin-top: 18px;
+  background: #f2f2f0;
+  border-radius: 11px;
+  padding: 14px 16px;
+}
+.ntab-note .label {
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  margin-bottom: 5px;
+}
+.ntab-note p {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.ntab-source {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(29, 29, 31, 0.1);
+  color: var(--ink-dim);
+  font-size: 13px;
+}
+.ntab-source .picon { flex: none; color: var(--accent); }
+.ntab-source .stime {
+  color: var(--ink-mid);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.ntab-foot { text-align: center; }
+.ntab-next {
+  background: var(--white);
+  border: 1px solid rgba(29, 29, 31, 0.1);
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 24px;
+  border-radius: 10px;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.ntab-cta {
+  text-align: center;
+  margin-top: 32px;
+}
+
+@media (max-width: 640px) {
+  .ntab-bar { padding: 14px 16px; }
+  .ntab-card { padding: 22px; }
+  .ntab-cardwrap { padding: 0 14px 36px; }
+}
+
+@media (hover: hover) {
+  .ntab-next:hover { border-color: rgba(29, 29, 31, 0.4); transform: translateY(-1px); }
+}
+
 /* ----- Details ----- */
 
 .details-grid {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Video Notes for YouTube</title>
     <meta name="description"
-        content="Video Notes is a Chrome extension that anchors timestamped notes to the exact second of any YouTube video. Capture in flow, search across every video, share with one click." />
+        content="Video Notes is a Chrome extension that anchors timestamped notes to the exact second of any YouTube video. Capture in flow, search across every video, share with one click, and turn your notes into flashcards on every new tab." />
     <meta name="keywords"
         content="YouTube notes, timestamped notes, Chrome extension, productivity, inline workspace, flash cards" />
     <meta name="author" content="Pramesh Bajracharya" />
@@ -44,7 +44,7 @@
         "name": "Video Notes for YouTube",
         "operatingSystem": "Chrome, Brave, Edge, Firefox",
         "applicationCategory": "ProductivityApplication",
-        "description": "Video Notes anchors timestamped notes to YouTube videos with a one-key shortcut, a searchable popup index, shareable read-only links, and flash-card review.",
+        "description": "Video Notes anchors timestamped notes to YouTube videos with a one-key shortcut, a searchable popup index, shareable read-only links, and Gemini-powered flashcards on every new tab.",
         "url": "https://prameshbajra.github.io/video-notes/",
         "creator": { "@type": "Person", "name": "Pramesh Bajracharya" },
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
@@ -63,6 +63,7 @@
                 <a href="#capture">Capture</a>
                 <a href="#timeline">Timeline</a>
                 <a href="#popup">Popup</a>
+                <a href="#flashcards">Flashcards</a>
                 <a href="#privacy">Privacy</a>
                 <a href="#share">Share</a>
             </nav>
@@ -298,17 +299,93 @@
             </div>
         </section>
 
+        <!-- FLASHCARDS / NEW TAB -->
+        <section id="flashcards" class="section--light">
+            <div class="section-inner">
+                <div class="section-head">
+                    <p class="eyebrow">Review</p>
+                    <h2 class="display h2">Open a new tab.<br /><em class="accent">Get quizzed.</em></h2>
+                    <p class="lead">Switch on new-tab flashcards and every blank tab becomes one multiple-choice question — written by Gemini from the notes you actually took. Answer it, read the note behind it, and jump straight to that second of the video. Bring your own free key; it stays on your device.</p>
+                </div>
+                <div class="ntab-frame" aria-hidden="true">
+                    <div class="ntab-chrome">
+                        <div class="yt-dots"><span></span><span></span><span></span></div>
+                        <div class="ntab-omni"><span>🔍</span> Search or type a URL</div>
+                    </div>
+                    <div class="ntab-bar">
+                        <div class="ntab-brand">
+                            <img src="extension/icons/icon-128.png" alt="" width="26" height="26" />
+                            <span>Video Notes</span>
+                        </div>
+                        <button class="ntab-iconbtn" type="button" tabindex="-1">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="3" y="4" width="13" height="16" rx="2"></rect>
+                                <path d="M19 8v11a2 2 0 0 1-2 2H8"></path>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="ntab-clock">
+                        <div class="ntab-time-row">
+                            <span class="ntab-time">9:41</span>
+                            <span class="ntab-ampm">AM</span>
+                        </div>
+                        <div class="ntab-sub">Good morning · Sunday, June 21</div>
+                    </div>
+                    <div class="ntab-cardwrap">
+                        <div class="ntab-card">
+                            <div class="ntab-pill">
+                                <span class="dot"></span>
+                                <span class="txt">Designing a sample-based synth</span>
+                            </div>
+                            <p class="ntab-q">Why route the bass through a sidechain bus?</p>
+                            <div class="ntab-opts">
+                                <div class="ntab-opt ntab-opt--correct">
+                                    <span class="otext">Duck it under the kick for a cleaner low end</span>
+                                    <svg class="check" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg>
+                                </div>
+                                <div class="ntab-opt ntab-opt--wrong">
+                                    <span class="otext">Widen the stereo image of the sub</span>
+                                    <svg class="cross" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="3" stroke-linecap="round"><path d="M18 6L6 18M6 6l12 12"></path></svg>
+                                </div>
+                                <div class="ntab-opt ntab-opt--dim">
+                                    <span class="otext">Boost the overall track loudness</span>
+                                </div>
+                                <div class="ntab-opt ntab-opt--dim">
+                                    <span class="otext">Filter out low-frequency hum</span>
+                                </div>
+                            </div>
+                            <div class="ntab-note">
+                                <div class="label">FROM YOUR NOTE</div>
+                                <p>Sidechain bus routing — try in Live tonight.</p>
+                            </div>
+                            <div class="ntab-source">
+                                <svg class="picon" width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg>
+                                <span class="slabel">Jump to source</span>
+                                <span class="stime">00:34</span>
+                            </div>
+                        </div>
+                        <div class="ntab-foot">
+                            <button class="ntab-next" type="button" tabindex="-1">Next card →</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="ntab-cta">
+                    <a class="link-accent" href="https://aistudio.google.com/apikey" target="_blank" rel="noreferrer noopener">Grab a free Gemini key &nbsp;›</a>
+                </div>
+            </div>
+        </section>
+
         <!-- PRIVACY -->
         <section id="privacy" class="section--soft">
             <div class="section-inner">
                 <div class="section-head">
                     <p class="eyebrow">Privacy</p>
                     <h2 class="display h2">Yours by <em class="accent">default</em>.<br />Yours by <em class="accent">design</em>.</h2>
-                    <p class="lead">Every note lives in <span class="privacy-inline-code">chrome.storage.local</span> on your machine. No accounts. No sync. No servers. No telemetry.</p>
+                    <p class="lead">Every note lives in <span class="privacy-inline-code">chrome.storage.local</span> on your machine. No accounts. No sync. No telemetry.</p>
                 </div>
                 <div class="privacy-stats">
                     <div class="stat-card"><div class="n">100%</div><div class="l">Offline by default</div></div>
-                    <div class="stat-card"><div class="n">0</div><div class="l">Network permissions</div></div>
+                    <div class="stat-card"><div class="n">0</div><div class="l">Trackers</div></div>
                     <div class="stat-card"><div class="n">142 KB</div><div class="l">Bundle size</div></div>
                     <div class="stat-card"><div class="n">MIT</div><div class="l">Open source</div></div>
                 </div>
@@ -433,9 +510,9 @@
                             </div>
                         </div>
                         <div>
-                            <div class="detail-eyebrow">Flash cards</div>
-                            <h3>Review what stuck.</h3>
-                            <p>Bring your own Gemini API key (stored locally) and Video Notes turns every note you've ever taken into a flip-card deck for self-quizzing.</p>
+                            <div class="detail-eyebrow">Quiz mode</div>
+                            <h3>Quiz the full deck.</h3>
+                            <p>Prefer a focused session? Open the popup and play the whole deck end to end — the same Gemini-made questions, scored as you go.</p>
                         </div>
                     </article>
 

--- a/privacy.html
+++ b/privacy.html
@@ -58,7 +58,7 @@
             <div class="policy-hero-inner">
                 <p class="eyebrow">Privacy policy</p>
                 <h1>Privacy that doesn't read between the lines.</h1>
-                <p class="policy-meta">Effective March 28, 2024 · Last reviewed March 28, 2026</p>
+                <p class="policy-meta">Effective March 28, 2024 · Last reviewed June 21, 2026</p>
             </div>
         </section>
 
@@ -103,7 +103,7 @@
                         <li>Every note associated with that video, including timestamps and text.</li>
                     </ul>
                     <p>
-                        No data is transmitted unless you explicitly click the Share button.
+                        No data is transmitted unless you explicitly click the Share button or enable the optional flashcards feature (see section 5).
                         The extension does not request or infer usernames, email addresses, browsing history, or analytics identifiers.
                     </p>
                 </article>
@@ -127,6 +127,7 @@
                     <ul>
                         <li><strong>storage</strong> — allows the extension to store the notes you create in <code>chrome.storage.local</code>.</li>
                         <li><strong>host_permissions</strong> for <code>share-api.video-notes.workers.dev</code> — allows the extension to send note data to the share API when you explicitly click the Share button. No requests are made to this host unless you initiate a share action.</li>
+                        <li><strong>host_permissions</strong> for <code>generativelanguage.googleapis.com</code> — allows the optional flashcards feature to send your note text to Google's Gemini API to generate quiz questions, using an API key you provide. No requests are made to this host unless you enable flashcards and add your own key.</li>
                         <li><strong>content_scripts</strong> on <code>youtube.com</code> — injects the inline workspace that renders the note editor, timeline, and controls on youtube.com/watch pages.</li>
                     </ul>
                     <p>
@@ -137,7 +138,7 @@
                 <article class="policy-card">
                     <h2>5. Network access, disclosures, and third parties</h2>
                     <p>
-                        With the exception of the Share feature described below, the extension does not initiate outbound network requests.
+                        With the exception of the optional Share and flashcards features described below, the extension does not initiate outbound network requests.
                         No analytics SDKs, advertising services, or third-party processors are bundled with the codebase.
                         Video Notes does not sell, trade, or disclose your information to anyone.
                     </p>
@@ -148,12 +149,15 @@
                         The API stores this data to generate a unique, read-only shareable link. No other data (browsing history, cookies, device identifiers) is included in the request.
                         This feature is entirely opt-in — no network requests are made unless you explicitly initiate a share action.
                     </p>
+                    <p>
+                        <strong>Flashcards feature.</strong> Flashcards are off by default. If you enable them and provide your own Google Gemini API key, the extension sends your note text and the associated video titles directly from your browser to Google's Gemini API (<code>generativelanguage.googleapis.com</code>) to generate quiz questions. Your API key is stored only in <code>chrome.storage.local</code> on your device and is never sent to the developer. This data is processed by Google under Google's own terms and privacy policy; no note data is sent to the developer or any other third party. No requests are made unless you have enabled flashcards and added a key.
+                    </p>
                 </article>
 
                 <article class="policy-card">
                     <h2>6. Security measures</h2>
                     <p>
-                        Outside the optional Share feature, data never leaves your browser. Security focuses on minimizing attack surface:
+                        Outside the optional Share and flashcards features, data never leaves your browser. Security focuses on minimizing attack surface:
                     </p>
                     <ul>
                         <li>The extension injects lightweight, auditable scripts based on open-source code published at <a href="https://github.com/prameshbajra/video-notes" rel="noreferrer noopener">github.com/prameshbajra/video-notes</a>.</li>


### PR DESCRIPTION
## Summary

Brings the **new-tab flashcards** feature to the marketing site, and reconciles the privacy claims now that the feature calls the Gemini API.

### Landing page (`index.html`, `index.css`)
- New **Review** section: a faithful mock of the new-tab page — clock + greeting, an answered multiple-choice card (correct / wrong / dimmed states), the originating note, and a *Jump to source* footer.
- Added a **Flashcards** nav link and updated the `<meta>` description + JSON-LD.
- Retuned the existing flash-cards detail card to describe the in-popup **quiz mode**, so the two no longer duplicate each other.

### Privacy (`index.html`, `privacy.html`)
- Swapped the `0 — Network permissions` stat for `0 — Trackers` and removed the now-inaccurate "No servers" lead claim.
- Extended the privacy policy (§2, §4, §5, §6) to document the opt-in, bring-your-own-key Gemini data flow, and bumped the last-reviewed date to June 21, 2026.

No build step — the landing page is served statically, so the changes are live on refresh.
