### PR TITLE
Point install CTAs at the visitor's browser store

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                 <a href="#privacy">Privacy</a>
                 <a href="#share">Share</a>
             </nav>
-            <a class="nav-cta" href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to Chrome</a>
+            <a class="nav-cta" data-install href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to <span data-browser-name>Chrome</span></a>
             <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
                 <span></span>
                 <span></span>
@@ -83,7 +83,7 @@
                 <h1 class="display h1">Remember every insight, without leaving <span class="accent-text">YouTube</span>.</h1>
                 <p class="lead">A small Chrome extension that anchors your thoughts to the exact second of the video that produced them. <em>Press a key, write, return at will.</em></p>
                 <div class="hero-actions">
-                    <a class="btn btn--filled" href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to Chrome &nbsp;›</a>
+                    <a class="btn btn--filled" data-install href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to <span data-browser-name>Chrome</span> &nbsp;›</a>
                     <a class="btn btn--outline" href="https://youtu.be/rOi7xQ8DLpo?si=OpWF5CIDSqxy5SQ4" target="_blank" rel="noreferrer noopener">See it in action  &nbsp;›</a>
                 </div>
             </div>
@@ -538,7 +538,7 @@
             <h2 class="display cta-h">Install once.<br /><span class="accent-text">Take notes</span> on every video.</h2>
             <p class="lead">Couple seconds to install. No account, no signup. The next video you open is ready to be noted down at the exact second, in your own words.</p>
             <div class="cta-actions">
-                <a class="btn btn--filled-light" href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to Chrome — free</a>
+                <a class="btn btn--filled-light" data-install href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to <span data-browser-name>Chrome</span> — free</a>
                 <a class="btn btn--outline-light" href="https://github.com/prameshbajra/video-notes" rel="noreferrer noopener">View on GitHub</a>
             </div>
             <div class="cta-foot">

--- a/index.js
+++ b/index.js
@@ -27,3 +27,25 @@ if (nav && navToggle) {
 window.addEventListener("resize", () => {
     if (window.innerWidth > 900) closeNav();
 });
+
+// ---- Install CTA: point each install link at the visitor's browser store ----
+// HTML defaults to Chrome (works without JS); Firefox visitors get the AMO link.
+const STORES = {
+    chrome: {
+        url: "https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom",
+        name: "Chrome",
+    },
+    firefox: {
+        url: "https://addons.mozilla.org/firefox/addon/video-notes-for-youtube/",
+        name: "Firefox",
+    },
+};
+
+const installTarget = /firefox/i.test(navigator.userAgent) ? STORES.firefox : STORES.chrome;
+
+document.querySelectorAll("[data-install]").forEach((link) => {
+    link.href = installTarget.url;
+});
+document.querySelectorAll("[data-browser-name]").forEach((el) => {
+    el.textContent = installTarget.name;
+});

--- a/privacy.html
+++ b/privacy.html
@@ -45,7 +45,7 @@
                 <a href="privacy.html" aria-current="page">Privacy</a>
                 <a href="index.html#share">Share</a>
             </nav>
-            <a class="nav-cta" href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to Chrome</a>
+            <a class="nav-cta" data-install href="https://chromewebstore.google.com/detail/video-notes/phgnkidiglnijkpmmdjcgdkekfoelcom" rel="noreferrer noopener">Add to <span data-browser-name>Chrome</span></a>
             <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" data-nav-toggle>
                 <span></span>
                 <span></span>


### PR DESCRIPTION
Install buttons now detect the visitor's browser: Firefox users get the AMO listing (`video-notes-for-youtube`) and an "Add to Firefox" label; Chromium browsers, unknown UAs, and no-JS visitors get the Chrome Web Store (the HTML default, so it degrades gracefully). Covers all three landing-page CTAs (nav, hero, final CTA) and the shared privacy-page nav CTA via `index.js`.